### PR TITLE
Improved cache import file matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # podcast-playlist
 
-This project exists to help me transition podcast listening from [PodcastAddict](https://podcastaddict.com/) to a [Tangara](https://www.crowdsupply.com/cool-tech-zone/tangara). Ultimately it will tie into whatever process the [companion app](https://github.com/haileys/tangara-companion) uses to transfer media and playlists to the device and scrobbling back off.
+This project exists to help me transition podcast listening from [PodcastAddict](https://podcastaddict.com/) to a [Tangara](https://www.crowdsupply.com/cool-tech-zone/tangara).
 
 podcast-playlist currently supports fetching feeds, downloading episodes, building playlists and tracking listen history. It's probably 'good enough' to use, but I've not fully used it in anger yet, so there's likely quirks and bugs yet to be discovered!
 
@@ -94,7 +94,11 @@ You can also manually curate a history JSON and replace the one in the root data
 
 #### Audio
 
-Importing existing audio files is being tracked in issue [#15](https://github.com/Slord6/podcast-playlist/issues/15).
+Existing files can be imported provided there is enough metadata to match the file to an item in a feed.
+
+`cache import --path /home/user/Music/Podcasts/ --recursive --ignoreArtist`
+
+Removing `--ignoreArtist` will be quicker, but will mean that podcasts that have changed names, or files that don't have a valid tag (e.g. `artist`), will not find a match.
 
 ### Playlist creation
 

--- a/src/bufferedRequests.ts
+++ b/src/bufferedRequests.ts
@@ -26,7 +26,7 @@ export class BufferedRequests {
             } else {
                 BufferedRequests._logger(`New host: ${url.host}`, "Verbose");
                 BufferedRequests.lastRequests[url.host] = {
-                    queue: [() => resolve(fetch(url))]
+                    queue: [() => resolve(fetch(url, {redirect: "follow"}))]
                 }
                 const interval = setInterval(() => {
                     const queue = BufferedRequests.lastRequests[url.host].queue;

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -10,6 +10,9 @@ export class Downloader {
     private _source: FeedItem;
     private _feedItem: FeedItem;
     private _extension: string | null;
+    public set extension(value: string) {
+        this._extension = value;
+    }
     private _cache: Cache;
 
     constructor(feedItem: FeedItem, cache: Cache) {
@@ -73,7 +76,7 @@ export class Downloader {
                 } else {
                     Downloader._logger(`Downloading ${this._feedItem.title}...`);
                     Downloader._logger(`${this._source} ---> ${path}`, "Verbose");
-                    fetch(this._source.url).then(response => {
+                    fetch(this._source.url, {redirect: "follow"}).then(response => {
                         const webStream = stream.Readable.fromWeb(response.body as any).on("error", (err) => {
                             console.error(`(DOWNLOADER) Failed to download ${this._feedItem.title}`);
                             Downloader._logger(err.name, "Verbose");

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,8 @@ const argv = yargs(helpers.hideBin(process.argv))
                 .describe("path", "The path to the directory containing all the files")
                 .boolean("recursive")
                 .describe("recursive", "If set, recurses into subdirectories to find more files")
+                .boolean("ignoreArtist")
+                .describe("ignoreArtist", "If set, will ignore artist values in file metadata and try to match only on the title")
                 .demandOption("path")
             })
             .demand(1, 1);
@@ -187,7 +189,7 @@ switch (argv._[0]) {
             },
             "import": {
                 func: importCacheFiles,
-                args: [argv.path, argv.recursive]
+                args: [argv.path, argv.recursive, argv.ignoreArtist]
             }
         }, "Invalid cache command");
         break;
@@ -196,10 +198,11 @@ switch (argv._[0]) {
         break;
 }
 
-function importCacheFiles(path: string, recursive: boolean | undefined) {
+function importCacheFiles(path: string, recursive: boolean | undefined, ignoreArtist: boolean | undefined) {
     const cache = new Cache(CACHE_DIR);
     Logger.Log(`Importing existing files from ${path}`);
-    cache.import(path, recursive === true);
+    Logger.Log(`Importing with settings: recursive: ${recursive}, ignoreArtist: ${ignoreArtist}`, "VeryVerbose");
+    cache.import(path, recursive === true, ignoreArtist === true);
 }
 
 function handleCommand(command: string, mapping: CommandMapping, errorText: string) {

--- a/src/playlist/playlist.ts
+++ b/src/playlist/playlist.ts
@@ -55,6 +55,7 @@ export class Playlist {
     private saveM3U(playlist: M3uPlaylist) {
         this.createDirectories();
         let playlistString = playlist.getM3uString();
+        fs.writeFileSync(this.playlistM3UPath() + "detailed.playlist", playlistString);
 
         // TODO - remove when Tanagra correctly ignores comment lines
         playlistString = playlistString.split("\n").filter(l => !l.startsWith("#")).join("\n");


### PR DESCRIPTION
- Support matching only on playlist title
- Tweaks to follow redirects in a couple of `fetch` calls
- Output a playlist including `#directives` alongside the currently-plain one