### PR TITLE
Use the RSS feed as the source of truth for episode mime types

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -26,7 +26,7 @@ export class Downloader {
     constructor(feedItem: FeedItem, cache: Cache) {
         this._source = feedItem;
         const podcastDirName: string = Downloader.toSafeFileName(feedItem.author);
-        this._feedItem = new FeedItem(feedItem.title, new URL(`file://${cache.cacheDirectory}/${podcastDirName}/${Downloader.toSafeFileName(feedItem.title)}`), feedItem.pubdate, feedItem.author, feedItem.type);
+        this._feedItem = new FeedItem(feedItem.title, new URL(`file://${cache.cacheDirectory}/${podcastDirName}/${Downloader.toSafeFileName(feedItem.title)}`), feedItem.pubdate, feedItem.author, feedItem.type, feedItem.mediaType);
         this._extension = null;
         this._cache = cache;
     }
@@ -41,6 +41,15 @@ export class Downloader {
      */
     public getExtension(): Promise<string> {
         if (this._extension !== null) return new Promise<string>((r) => r(this._extension!));
+
+        if (this._feedItem.mediaType !== null) {
+            const ext = MimeTypes.getAudioExtension(this._feedItem.mediaType);
+            if (ext !== "bin") {
+                this._extension = ext;
+                Downloader._logger(`Using media type from feed item: ${this._extension}`, "VeryVerbose");
+                return new Promise<string>((r) => r(this._extension!));
+            }
+        }
 
         return fetch(this._source.url, {
             method: "HEAD",

--- a/src/feedItem.ts
+++ b/src/feedItem.ts
@@ -46,13 +46,18 @@ export class FeedItem {
     public set type(value: EpisodeType) {
         this._type = value;
     }
+    private _mediaType: string | null;;
+    public get mediaType(): string | null {
+        return this._mediaType;
+    }
 
-    constructor(title: string, url: URL, pubdate: string, author: string, type: EpisodeType) {
+    constructor(title: string, url: URL, pubdate: string, author: string, type: EpisodeType, mediaType: string | null) {
         this._title = title;
         this._url = url;
         this._pubdate = pubdate;
         this._author = author;
         this._type = type;
+        this._mediaType = mediaType || null;
     }
 
     public toString(): string {
@@ -61,12 +66,12 @@ export class FeedItem {
 
     public static fromJSON(json: string): FeedItem {
         const rawItem = JSON.parse(json);
-        return new FeedItem(rawItem._title, new URL(rawItem._url), rawItem._pubdate, rawItem._author, rawItem._type || "full");
+        return new FeedItem(rawItem._title, new URL(rawItem._url), rawItem._pubdate, rawItem._author, rawItem._type || "full", rawItem._mediaType || null);
     }
 
     public static fromHistoryItem(historyItem: HistoryItem, feeds: Feed[]): FeedItem | null {
         const feed: Feed | undefined = feeds.filter(feed => feed.name == historyItem.podcastName)[0];
-        if(!feed) return null;
+        if (!feed) return null;
         const feedItem = feed.items.filter(item => item.title == historyItem.episodeName)[0];
         return feedItem ? feedItem : null;
     }

--- a/src/ingestion/rssFeedImporter.ts
+++ b/src/ingestion/rssFeedImporter.ts
@@ -17,15 +17,14 @@ export class RSSFeedImporter {
         RSSFeedImporter._logger(`Parsing ${this.rssUrl}...`, "Verbose");
         return BufferedRequests.fetch(this.rssUrl).then(resp => resp.text(), (reason) => console.error(`(RSS) Fetch-parse of ${this.rssUrl} failed: ${reason}`))
             .then(rssText => {
-                if(!rssText) return null;
+                if (!rssText) return null;
                 return parser.parseString(rssText).then(feed => {
                     const feedTitle = feed.title ? feed.title : "<Unknown Author>";
                     const items: FeedItem[] = feed.items.map((item) => {
                         const title = item.title ? item.title : "<Unknown title>";
                         const urlLoc = item.enclosure?.url;
                         const url = urlLoc ? new URL(urlLoc) : new URL("https://example.com"); // TODO better handling of missing URL
-                        // TODO extract episode type - blocked by https://github.com/rbren/rss-parser/issues/271
-                        return new FeedItem(title, url, item.pubDate ? item.pubDate : "", feedTitle, item.itunes?.episodeType || "full");
+                        return new FeedItem(title, url, item.pubDate ? item.pubDate : "", feedTitle, item.itunes?.episodeType || "full", item.enclosure?.type || null);
                     });
 
                     const imgUrl = feed.image?.url ? new URL(feed.image?.url) : new URL("https://example.com"); // TODO better handling of missing URL


### PR DESCRIPTION
We previosuly used the mime type from the podcast source URL, by making a HEAD request. This didn't work for octect-stream sources, and for some redirected URL sources. We now use the mime type of the RSS feed items as the primary source, and fall back to a head request if that's unset (seemingly very rare).